### PR TITLE
feat: add runtime reflection cache

### DIFF
--- a/HCommons.sln
+++ b/HCommons.sln
@@ -16,6 +16,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HCommons.Benchmarks", "sand
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HCommons.Void", "src\HCommons.Void\HCommons.Void.csproj", "{E60D5F86-0B1B-4637-99A4-2621025AFF44}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HCommons.Reflection", "src\HCommons.Reflection\HCommons.Reflection.csproj", "{1BA9DFA3-99F1-41DF-9A8B-95A3CFB3596C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HCommons.Reflection.Tests.Fixture", "src\HCommons.Reflection.Tests.Fixture\HCommons.Reflection.Tests.Fixture.csproj", "{D76B62F5-E4D2-4E43-A270-766362B6D730}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,5 +58,13 @@ Global
 		{E60D5F86-0B1B-4637-99A4-2621025AFF44}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E60D5F86-0B1B-4637-99A4-2621025AFF44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E60D5F86-0B1B-4637-99A4-2621025AFF44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BA9DFA3-99F1-41DF-9A8B-95A3CFB3596C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BA9DFA3-99F1-41DF-9A8B-95A3CFB3596C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BA9DFA3-99F1-41DF-9A8B-95A3CFB3596C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BA9DFA3-99F1-41DF-9A8B-95A3CFB3596C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D76B62F5-E4D2-4E43-A270-766362B6D730}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D76B62F5-E4D2-4E43-A270-766362B6D730}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D76B62F5-E4D2-4E43-A270-766362B6D730}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D76B62F5-E4D2-4E43-A270-766362B6D730}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A C# commons library providing utility types and helper functions for .NET appli
 - **Buffers**: Memory-efficient pooled array types for high-performance scenarios
 - **Math**: Mathematical helper methods and extensions for common operations
 - **Monads**: Functional programming utilities for safe and expressive error handling
+- **Types**: Cached runtime discovery of assignable types across loaded assemblies
 
 ## Installation
 
@@ -579,6 +580,27 @@ Cancelled cancellation2 = "User requested"; // Implicit conversion
 // Cancellation with value
 Cancelled<int> cancellation3 = Cancelled<int>.Because(42, "Partial result");
 ```
+
+## Types
+
+The `HCommons.Reflection` namespace provides cached runtime type discovery without taking a dependency on Unity.
+
+```csharp
+using HCommons.Reflection;
+
+IReadOnlyList<Type> handlers = RuntimeTypeCache.TypesDerivedFrom<IHandler>();
+
+using IDisposable binding = RuntimeTypeCache.Bind<IHandler>(updatedHandlers => {
+    // The first snapshot is delivered immediately. Later snapshots are delivered
+    // when newly loaded assemblies add matching types.
+});
+```
+
+Reflection metadata can be removed by .NET trimming and Unity managed code stripping. Applications must preserve types that are discovered only through this API. In Unity, use a `link.xml` file, `[Preserve]`, or an equivalent linker annotation. `UnityEditor.TypeCache` is faster for editor-only discovery; `RuntimeTypeCache` is intended for player/runtime and shared-library code.
+
+Assemblies loaded after the first query are scanned incrementally. Runtime-emitted types added after their assembly has loaded are not detectable automatically; call `RuntimeTypeCache.Clear()` to force a complete rescan.
+
+The cache holds strong references to discovered `Assembly` and `Type` objects. Clear it and release returned snapshots before unloading a collectible `AssemblyLoadContext`.
 
 ## Target Frameworks
 

--- a/sandbox/HCommons.Benchmarks/HCommons.Benchmarks.csproj
+++ b/sandbox/HCommons.Benchmarks/HCommons.Benchmarks.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\HCommons.Disposables\HCommons.Disposables.csproj" />
+      <ProjectReference Include="..\..\src\HCommons.Reflection\HCommons.Reflection.csproj" />
     </ItemGroup>
 
 </Project>

--- a/sandbox/HCommons.Benchmarks/Program.cs
+++ b/sandbox/HCommons.Benchmarks/Program.cs
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Running;
 using HCommons.Disposables;
+using HCommons.Reflection;
 using Perfolizer.Horology;
 
 BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args: null, new AccurateConfig());
@@ -76,6 +77,24 @@ public sealed class AccurateConfig : ManualConfig {
 
         WithOptions(ConfigOptions.KeepBenchmarkFiles); // Keep artifacts for inspection
         Orderer = new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest);
+    }
+}
+
+[MemoryDiagnoser]
+public class RuntimeTypeCacheBench {
+    [GlobalSetup]
+    public void GlobalSetup() {
+        RuntimeTypeCache.Clear();
+        RuntimeTypeCache.TypesDerivedFrom<IDisposable>();
+    }
+
+    [Benchmark(Baseline = true)]
+    public IReadOnlyList<Type> CachedQuery() => RuntimeTypeCache.TypesDerivedFrom<IDisposable>();
+
+    [Benchmark]
+    public IReadOnlyList<Type> FullRebuild() {
+        RuntimeTypeCache.Clear();
+        return RuntimeTypeCache.TypesDerivedFrom<IDisposable>();
     }
 }
 

--- a/src/HCommons.Reflection.Tests.Fixture/FixtureDisposable.cs
+++ b/src/HCommons.Reflection.Tests.Fixture/FixtureDisposable.cs
@@ -1,0 +1,5 @@
+namespace HCommons.Reflection.Tests.Fixture;
+
+public sealed class FixtureDisposable : IDisposable {
+    public void Dispose() { }
+}

--- a/src/HCommons.Reflection.Tests.Fixture/HCommons.Reflection.Tests.Fixture.csproj
+++ b/src/HCommons.Reflection.Tests.Fixture/HCommons.Reflection.Tests.Fixture.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <RootNamespace>HCommons.Reflection.Tests.Fixture</RootNamespace>
+    </PropertyGroup>
+
+</Project>

--- a/src/HCommons.Reflection/HCommons.Reflection.csproj
+++ b/src/HCommons.Reflection/HCommons.Reflection.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Package Identity -->
+        <Version>1.0.0</Version>
+        <Title>HCommons.Reflection</Title>
+        <Description>Runtime type discovery and reflection utilities.</Description>
+        <PackageTags>Types Reflection</PackageTags>
+
+        <!-- Override Directory.Build.props to allow Nuget generation -->
+        <IsPackable>true</IsPackable>
+        <RootNamespace>HCommons.Reflection</RootNamespace>
+    </PropertyGroup>
+
+    <!-- Dependencies for Polyfills on older targets -->
+    <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
+        <PackageReference Include="PolySharp" Version="1.15.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/src/HCommons.Reflection/RuntimeTypeCache.cs
+++ b/src/HCommons.Reflection/RuntimeTypeCache.cs
@@ -1,0 +1,557 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace HCommons.Reflection;
+
+/// <summary>
+/// Discovers and caches types from the assemblies loaded in the current application domain.
+/// </summary>
+/// <remarks>
+/// Results are cached per assembly. Assemblies loaded after the first query are scanned
+/// incrementally and merged into existing query results.
+/// </remarks>
+public static class RuntimeTypeCache {
+    static readonly object s_gate = new();
+    static readonly Dictionary<Assembly, Type[]> s_assemblyTypes = new();
+    static readonly Dictionary<Type, QueryEntry> s_queries = new();
+    static readonly HashSet<Assembly> s_pendingAssemblies = new();
+
+    static bool s_initialized;
+    static bool s_snapshotRebuildPending;
+    static bool s_workerScheduled;
+
+    static RuntimeTypeCache() {
+        AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+    }
+
+    /// <summary>
+    /// Returns every loaded type assignable to <typeparamref name="TBase"/>, excluding
+    /// <typeparamref name="TBase"/> itself.
+    /// </summary>
+    /// <typeparam name="TBase">The base class or interface to query.</typeparam>
+    /// <returns>An immutable snapshot of the matching types. Result order is unspecified.</returns>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+        "Runtime type discovery cannot guarantee that types have been preserved by trimming.")]
+#endif
+    public static IReadOnlyList<Type> TypesDerivedFrom<TBase>() => TypesDerivedFrom(typeof(TBase));
+
+    /// <summary>
+    /// Returns every loaded type assignable to <paramref name="baseType"/>, excluding
+    /// <paramref name="baseType"/> itself.
+    /// </summary>
+    /// <param name="baseType">The base class or interface to query.</param>
+    /// <returns>An immutable snapshot of the matching types. Result order is unspecified.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="baseType"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+        "Runtime type discovery cannot guarantee that types have been preserved by trimming.")]
+#endif
+    public static IReadOnlyList<Type> TypesDerivedFrom(Type baseType) {
+        if (baseType is null) {
+            throw new ArgumentNullException(nameof(baseType));
+        }
+
+        IReadOnlyList<Type> snapshot;
+        List<Notification>? notifications;
+
+        lock (s_gate) {
+            EnsureInitialized();
+            notifications = ProcessPendingAssemblies();
+            snapshot = GetOrCreateQuery(baseType).Snapshot;
+        }
+
+        Publish(notifications);
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Observes types assignable to <typeparamref name="TBase"/> on the current synchronization context.
+    /// </summary>
+    /// <param name="onChanged">
+    /// A callback that receives the initial snapshot synchronously and later replacement snapshots when the result changes.
+    /// </param>
+    /// <returns>A subscription that stops future notifications when disposed.</returns>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+        "Runtime type discovery cannot guarantee that types have been preserved by trimming.")]
+#endif
+    public static IDisposable Bind<TBase>(Action<IReadOnlyList<Type>> onChanged) =>
+        Bind(typeof(TBase), onChanged, SynchronizationContext.Current);
+
+    /// <summary>
+    /// Observes types assignable to <typeparamref name="TBase"/> on a specified synchronization context.
+    /// </summary>
+    /// <param name="onChanged">
+    /// A callback that receives the initial snapshot synchronously and later replacement snapshots when the result changes.
+    /// </param>
+    /// <param name="synchronizationContext">
+    /// The context used for later notifications, or <see langword="null"/> to use the thread pool.
+    /// </param>
+    /// <returns>A subscription that stops future notifications when disposed.</returns>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+        "Runtime type discovery cannot guarantee that types have been preserved by trimming.")]
+#endif
+    public static IDisposable Bind<TBase>(
+        Action<IReadOnlyList<Type>> onChanged,
+        SynchronizationContext? synchronizationContext) =>
+        Bind(typeof(TBase), onChanged, synchronizationContext);
+
+    /// <summary>
+    /// Observes types assignable to <paramref name="baseType"/> on the current synchronization context.
+    /// </summary>
+    /// <param name="baseType">The base class or interface to query.</param>
+    /// <param name="onChanged">
+    /// A callback that receives the initial snapshot synchronously and later replacement snapshots when the result changes.
+    /// </param>
+    /// <returns>A subscription that stops future notifications when disposed.</returns>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+        "Runtime type discovery cannot guarantee that types have been preserved by trimming.")]
+#endif
+    public static IDisposable Bind(Type baseType, Action<IReadOnlyList<Type>> onChanged) =>
+        Bind(baseType, onChanged, SynchronizationContext.Current);
+
+    /// <summary>
+    /// Observes types assignable to <paramref name="baseType"/> on a specified synchronization context.
+    /// </summary>
+    /// <param name="baseType">The base class or interface to query.</param>
+    /// <param name="onChanged">
+    /// A callback that receives the initial snapshot synchronously and later replacement snapshots when the result changes.
+    /// </param>
+    /// <param name="synchronizationContext">
+    /// The context used for later notifications, or <see langword="null"/> to use the thread pool.
+    /// </param>
+    /// <returns>A subscription that stops future notifications when disposed.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="baseType"/> or <paramref name="onChanged"/> is <see langword="null"/>.
+    /// </exception>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+        "Runtime type discovery cannot guarantee that types have been preserved by trimming.")]
+#endif
+    public static IDisposable Bind(
+        Type baseType,
+        Action<IReadOnlyList<Type>> onChanged,
+        SynchronizationContext? synchronizationContext)
+    {
+        if (baseType is null)
+            throw new ArgumentNullException(nameof(baseType));
+
+        if (onChanged is null)
+            throw new ArgumentNullException(nameof(onChanged));
+
+        Binding binding;
+        IReadOnlyList<Type> snapshot;
+        List<Notification>? notifications;
+
+        lock (s_gate) {
+            EnsureInitialized();
+            notifications = ProcessPendingAssemblies();
+
+            var query = GetOrCreateQuery(baseType);
+            binding = new Binding(baseType, onChanged, synchronizationContext);
+            query.Bindings.Add(binding);
+            snapshot = query.Snapshot;
+        }
+
+        Publish(notifications);
+        binding.Start(snapshot);
+        return binding;
+    }
+
+    /// <summary>
+    /// Invalidates all scanned assemblies and cached query results.
+    /// </summary>
+    /// <remarks>
+    /// Active bindings remain registered. When bindings exist, rebuilding is scheduled in the
+    /// background; otherwise it is deferred until the next query or binding.
+    /// </remarks>
+    public static void Clear() {
+        lock (s_gate) {
+            s_assemblyTypes.Clear();
+            s_pendingAssemblies.Clear();
+
+            foreach (var query in s_queries.Values) {
+                query.BeginRebuild();
+            }
+
+            s_snapshotRebuildPending = s_queries.Count > 0;
+
+            s_initialized = true;
+            QueueCurrentAssemblies();
+
+            if (HasBindings()) {
+                ScheduleWorker();
+            }
+        }
+    }
+
+    static void OnAssemblyLoad(object? sender, AssemblyLoadEventArgs args) {
+        lock (s_gate) {
+            if (!s_assemblyTypes.ContainsKey(args.LoadedAssembly)) {
+                s_pendingAssemblies.Add(args.LoadedAssembly);
+            }
+
+            if (HasBindings()) {
+                ScheduleWorker();
+            }
+        }
+    }
+
+    static void EnsureInitialized() {
+        if (s_initialized) {
+            return;
+        }
+
+        s_initialized = true;
+        QueueCurrentAssemblies();
+    }
+
+    static void QueueCurrentAssemblies() {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
+            if (!s_assemblyTypes.ContainsKey(assembly)) {
+                s_pendingAssemblies.Add(assembly);
+            }
+        }
+    }
+
+    static List<Notification>? ProcessPendingAssemblies() {
+        if (s_pendingAssemblies.Count == 0 && !s_snapshotRebuildPending) {
+            return null;
+        }
+
+        var changedQueries = new HashSet<QueryEntry>();
+
+        while (s_pendingAssemblies.Count > 0) {
+            var enumerator = s_pendingAssemblies.GetEnumerator();
+            enumerator.MoveNext();
+            var assembly = enumerator.Current;
+            enumerator.Dispose();
+            s_pendingAssemblies.Remove(assembly);
+
+            if (s_assemblyTypes.ContainsKey(assembly)) {
+                continue;
+            }
+
+            var assemblyTypes = GetLoadableTypes(assembly);
+            s_assemblyTypes.Add(assembly, assemblyTypes);
+
+            foreach (var query in s_queries.Values) {
+                if (query.AddMatches(assemblyTypes)) {
+                    changedQueries.Add(query);
+                }
+            }
+        }
+
+        foreach (var query in s_queries.Values) {
+            if (query.RequiresSnapshotRebuild) {
+                changedQueries.Add(query);
+            }
+        }
+
+        s_snapshotRebuildPending = false;
+
+        List<Notification>? notifications = null;
+
+        foreach (var query in changedQueries) {
+            var changed = query.PublishSnapshot();
+            if (!changed) {
+                continue;
+            }
+
+            foreach (var binding in query.Bindings) {
+                notifications ??= new List<Notification>();
+                notifications.Add(new Notification(binding, query.Snapshot));
+            }
+        }
+
+        return notifications;
+    }
+
+    static QueryEntry GetOrCreateQuery(Type baseType) {
+        if (s_queries.TryGetValue(baseType, out var query)) {
+            return query;
+        }
+
+        query = new QueryEntry(baseType);
+        foreach (var assemblyTypes in s_assemblyTypes.Values) {
+            query.AddMatches(assemblyTypes);
+        }
+
+        query.PublishInitialSnapshot();
+        s_queries.Add(baseType, query);
+        return query;
+    }
+
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "The public discovery APIs warn callers, and Unity consumers are documented to preserve discovered types.")]
+#endif
+    static Type[] GetLoadableTypes(Assembly assembly) {
+        try {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception) {
+            return exception.Types.Where(type => type is not null).Cast<Type>().ToArray();
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException) {
+            Trace.TraceWarning("Unable to scan assembly '{0}' for types: {1}", assembly.FullName, exception);
+            return Array.Empty<Type>();
+        }
+    }
+
+    static bool HasBindings() {
+        foreach (var query in s_queries.Values) {
+            if (query.Bindings.Count > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static void ScheduleWorker() {
+        if (s_workerScheduled) {
+            return;
+        }
+
+        s_workerScheduled = true;
+
+        try {
+            if (!ThreadPool.QueueUserWorkItem(_ => ProcessPendingAssembliesOnWorker())) {
+                s_workerScheduled = false;
+                Trace.TraceWarning("Unable to queue the runtime type cache worker.");
+            }
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException) {
+            s_workerScheduled = false;
+            Trace.TraceWarning("Unable to queue the runtime type cache worker: {0}", exception);
+        }
+    }
+
+    static void ProcessPendingAssembliesOnWorker() {
+        List<Notification>? notifications;
+
+        lock (s_gate) {
+            notifications = ProcessPendingAssemblies();
+            s_workerScheduled = false;
+        }
+
+        Publish(notifications);
+    }
+
+    static void Publish(List<Notification>? notifications) {
+        if (notifications is null) {
+            return;
+        }
+
+        foreach (var notification in notifications) {
+            notification.Binding.Queue(notification.Snapshot);
+        }
+    }
+
+    static void Unbind(Binding binding) {
+        lock (s_gate) {
+            if (s_queries.TryGetValue(binding.BaseType, out var query)) {
+                query.Bindings.Remove(binding);
+            }
+        }
+    }
+
+    sealed class QueryEntry {
+        readonly Type _baseType;
+        HashSet<Type>? _preRebuildTypes;
+
+        public QueryEntry(Type baseType) {
+            _baseType = baseType;
+        }
+
+        public HashSet<Type> Types { get; } = new();
+
+        public IReadOnlyList<Type> Snapshot { get; private set; } = Array.AsReadOnly(Array.Empty<Type>());
+
+        public List<Binding> Bindings { get; } = new();
+
+        public bool RequiresSnapshotRebuild => _preRebuildTypes is not null;
+
+        public bool AddMatches(Type[] types) {
+            var changed = false;
+
+            foreach (var type in types) {
+                if (type != _baseType && _baseType.IsAssignableFrom(type)) {
+                    changed |= Types.Add(type);
+                }
+            }
+
+            return changed;
+        }
+
+        public void BeginRebuild() {
+            _preRebuildTypes ??= new HashSet<Type>(Types);
+            Types.Clear();
+        }
+
+        public void PublishInitialSnapshot() {
+            Snapshot = CreateSnapshot();
+        }
+
+        public bool PublishSnapshot() {
+            var changed = _preRebuildTypes is null || !_preRebuildTypes.SetEquals(Types);
+            Snapshot = CreateSnapshot();
+            _preRebuildTypes = null;
+            return changed;
+        }
+
+        IReadOnlyList<Type> CreateSnapshot() => Array.AsReadOnly(Types.ToArray());
+    }
+
+    readonly record struct Notification(Binding Binding, IReadOnlyList<Type> Snapshot);
+
+    sealed class Binding : IDisposable {
+        readonly object _gate = new();
+        readonly Action<IReadOnlyList<Type>> _onChanged;
+        readonly SynchronizationContext? _synchronizationContext;
+
+        IReadOnlyList<Type>? _pendingSnapshot;
+        bool _started;
+        bool _deliveryInProgress;
+        bool _dispatchScheduled;
+        bool _disposed;
+
+        public Binding(
+            Type baseType,
+            Action<IReadOnlyList<Type>> onChanged,
+            SynchronizationContext? synchronizationContext) {
+            BaseType = baseType;
+            _onChanged = onChanged;
+            _synchronizationContext = synchronizationContext;
+        }
+
+        public Type BaseType { get; }
+
+        public void Dispose() {
+            lock (_gate) {
+                if (_disposed) {
+                    return;
+                }
+
+                _disposed = true;
+                _pendingSnapshot = null;
+            }
+
+            Unbind(this);
+        }
+
+        public void Start(IReadOnlyList<Type> snapshot) {
+            IReadOnlyList<Type>? snapshotToDeliver;
+
+            lock (_gate) {
+                if (_disposed) {
+                    return;
+                }
+
+                _started = true;
+                _pendingSnapshot ??= snapshot;
+                snapshotToDeliver = _pendingSnapshot;
+                _pendingSnapshot = null;
+                _deliveryInProgress = true;
+            }
+
+            Deliver(snapshotToDeliver);
+        }
+
+        public void Queue(IReadOnlyList<Type> snapshot) {
+            var shouldSchedule = false;
+
+            lock (_gate) {
+                if (_disposed) {
+                    return;
+                }
+
+                _pendingSnapshot = snapshot;
+
+                if (_started && !_deliveryInProgress && !_dispatchScheduled) {
+                    _dispatchScheduled = true;
+                    shouldSchedule = true;
+                }
+            }
+
+            if (shouldSchedule) {
+                ScheduleDispatch();
+            }
+        }
+
+        void ScheduleDispatch() {
+            try {
+                if (_synchronizationContext is not null) {
+                    _synchronizationContext.Post(_ => Dispatch(), null);
+                    return;
+                }
+
+                if (ThreadPool.QueueUserWorkItem(_ => Dispatch())) {
+                    return;
+                }
+
+                Trace.TraceWarning("Unable to queue a runtime type cache binding callback.");
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException) {
+                Trace.TraceWarning("Unable to queue a runtime type cache binding callback: {0}", exception);
+            }
+
+            lock (_gate) {
+                _dispatchScheduled = false;
+            }
+        }
+
+        void Dispatch() {
+            IReadOnlyList<Type>? snapshot;
+
+            lock (_gate) {
+                _dispatchScheduled = false;
+
+                if (_disposed || _pendingSnapshot is null) {
+                    return;
+                }
+
+                snapshot = _pendingSnapshot;
+                _pendingSnapshot = null;
+                _deliveryInProgress = true;
+            }
+
+            Deliver(snapshot);
+        }
+
+        void Deliver(IReadOnlyList<Type> snapshot) {
+            try {
+                _onChanged(snapshot);
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException) {
+                Trace.TraceWarning("A runtime type cache binding callback failed: {0}", exception);
+            }
+            finally {
+                CompleteDelivery();
+            }
+        }
+
+        void CompleteDelivery() {
+            var shouldSchedule = false;
+
+            lock (_gate) {
+                _deliveryInProgress = false;
+
+                if (!_disposed && _started && _pendingSnapshot is not null && !_dispatchScheduled) {
+                    _dispatchScheduled = true;
+                    shouldSchedule = true;
+                }
+            }
+
+            if (shouldSchedule) {
+                ScheduleDispatch();
+            }
+        }
+    }
+}

--- a/src/HCommons.Tests/HCommons.Tests.csproj
+++ b/src/HCommons.Tests/HCommons.Tests.csproj
@@ -16,6 +16,7 @@
         <!-- Disable Nuget generation -->
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);IL2026</NoWarn>
     </PropertyGroup>
 
     <!-- Add .NET Framework test -->
@@ -56,7 +57,16 @@
         <ProjectReference Include="..\HCommons.Buffers\HCommons.Buffers.csproj"/>
         <ProjectReference Include="..\HCommons.Math\HCommons.Math.csproj"/>
         <ProjectReference Include="..\HCommons.Disposables\HCommons.Disposables.csproj"/>
+        <ProjectReference Include="..\HCommons.Reflection\HCommons.Reflection.csproj"/>
+        <ProjectReference Include="..\HCommons.Reflection.Tests.Fixture\HCommons.Reflection.Tests.Fixture.csproj"
+                          ReferenceOutputAssembly="false"
+                          AdditionalProperties="Configuration=$(Configuration)"/>
     </ItemGroup>
+
+    <Target Name="CopyTypeCacheTestFixture" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+        <Copy SourceFiles="..\HCommons.Reflection.Tests.Fixture\bin\$(Configuration)\netstandard2.0\HCommons.Reflection.Tests.Fixture.dll"
+              DestinationFolder="$(OutDir)" />
+    </Target>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" Condition="'$(TargetFramework)' == 'net6.0'"/>

--- a/src/HCommons.Tests/Reflection/RuntimeTypeCacheTests.cs
+++ b/src/HCommons.Tests/Reflection/RuntimeTypeCacheTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using HCommons.Reflection;
+
+namespace HCommons.Tests;
+
+[Collection(nameof(NonParallelTests))]
+public sealed class RuntimeTypeCacheTests {
+    [Fact]
+    public void TypesDerivedFrom_ReturnsEveryAssignableTypeExceptTheQueriedType() {
+        RuntimeTypeCache.Clear();
+
+        var types = RuntimeTypeCache.TypesDerivedFrom<ITestMarker>();
+
+        types.ShouldContain(typeof(IDerivedTestMarker));
+        types.ShouldContain(typeof(AbstractTestMarker));
+        types.ShouldContain(typeof(ConcreteTestMarker));
+        types.ShouldNotContain(typeof(ITestMarker));
+    }
+
+    [Fact]
+    public void TypesDerivedFrom_TypeOverloadReturnsTheCachedImmutableSnapshot() {
+        RuntimeTypeCache.Clear();
+
+        var first = RuntimeTypeCache.TypesDerivedFrom(typeof(ITestMarker));
+        var second = RuntimeTypeCache.TypesDerivedFrom(typeof(ITestMarker));
+
+        second.ShouldBeSameAs(first);
+        var mutableView = first.ShouldBeAssignableTo<IList<Type>>();
+        mutableView.IsReadOnly.ShouldBeTrue();
+        Should.Throw<NotSupportedException>(() => mutableView.Add(typeof(string)));
+    }
+
+    [Fact]
+    public void Clear_RebuildsTheSnapshotWithoutChangingItsContents() {
+        RuntimeTypeCache.Clear();
+        var beforeClear = RuntimeTypeCache.TypesDerivedFrom<ITestMarker>();
+
+        RuntimeTypeCache.Clear();
+        var afterClear = RuntimeTypeCache.TypesDerivedFrom<ITestMarker>();
+
+        afterClear.ShouldNotBeSameAs(beforeClear);
+        afterClear.ToHashSet().SetEquals(beforeClear).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TypesDerivedFrom_NullTypeThrows() {
+        Should.Throw<ArgumentNullException>(() => RuntimeTypeCache.TypesDerivedFrom(null!));
+    }
+
+    [Fact]
+    public void Bind_NullCallbackThrows() {
+        Should.Throw<ArgumentNullException>(() =>
+            RuntimeTypeCache.Bind(typeof(ITestMarker), null!, synchronizationContext: null));
+    }
+
+    [Fact]
+    public void Bind_DeliversTheInitialSnapshotSynchronously() {
+        RuntimeTypeCache.Clear();
+        IReadOnlyList<Type>? received = null;
+
+        using var binding = RuntimeTypeCache.Bind<ITestMarker>(types => received = types);
+
+        received.ShouldNotBeNull();
+        received.ShouldContain(typeof(ConcreteTestMarker));
+    }
+
+    [Fact]
+    public void Bind_LoadedAssemblyPublishesOnlyAffectedQueriesOnTheCapturedContext() {
+        RuntimeTypeCache.Clear();
+        var context = new PumpSynchronizationContext();
+        var disposableSnapshots = new List<IReadOnlyList<Type>>();
+        var markerNotificationCount = 0;
+        var disposedNotificationCount = 0;
+
+        using var disposableBinding = RuntimeTypeCache.Bind(
+            typeof(IDisposable),
+            types => disposableSnapshots.Add(types),
+            context);
+        using var markerBinding = RuntimeTypeCache.Bind<ITestMarker>(
+            _ => markerNotificationCount++,
+            context);
+        var disposedBinding = RuntimeTypeCache.Bind(
+            typeof(IDisposable),
+            _ => disposedNotificationCount++,
+            context);
+        disposedBinding.Dispose();
+        disposedBinding.Dispose();
+
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "HCommons.Reflection.Tests.Fixture.dll");
+        File.Exists(fixturePath).ShouldBeTrue($"Fixture assembly was not copied to '{fixturePath}'.");
+
+        var fixtureAssembly = Assembly.Load(File.ReadAllBytes(fixturePath));
+        var fixtureType = fixtureAssembly.GetType(
+            "HCommons.Reflection.Tests.Fixture.FixtureDisposable",
+            throwOnError: true)!;
+
+        context.WaitForPendingCallback().ShouldBeTrue("A bound query should be updated after an assembly load.");
+        disposableSnapshots.Count.ShouldBe(1, "Later notifications must be posted to the captured context.");
+
+        context.RunAll();
+
+        disposableSnapshots.Count.ShouldBe(2);
+        disposableSnapshots[^1].ShouldContain(fixtureType);
+        markerNotificationCount.ShouldBe(1, "An assembly with no marker implementations must not publish that query.");
+        disposedNotificationCount.ShouldBe(1, "A disposed binding must suppress pending and future notifications.");
+    }
+
+    [Fact]
+    public void TypesDerivedFrom_ConcurrentFirstReadsReturnTheSameSnapshot() {
+        RuntimeTypeCache.Clear();
+        var snapshots = new ConcurrentBag<IReadOnlyList<Type>>();
+
+        Parallel.For(0, 64, _ => snapshots.Add(RuntimeTypeCache.TypesDerivedFrom<ITestMarker>()));
+
+        var expected = snapshots.First();
+        snapshots.ShouldAllBe(snapshot => ReferenceEquals(snapshot, expected));
+    }
+
+    interface ITestMarker;
+
+    interface IDerivedTestMarker : ITestMarker;
+
+    abstract class AbstractTestMarker : ITestMarker;
+
+    sealed class ConcreteTestMarker : AbstractTestMarker;
+
+    sealed class PumpSynchronizationContext : SynchronizationContext {
+        readonly ConcurrentQueue<Action> _callbacks = new();
+
+        public override void Post(SendOrPostCallback callback, object? state) =>
+            _callbacks.Enqueue(() => callback(state));
+
+        public bool WaitForPendingCallback() => SpinWait.SpinUntil(() => !_callbacks.IsEmpty, TimeSpan.FromSeconds(5));
+
+        public void RunAll() {
+            while (_callbacks.TryDequeue(out var callback)) {
+                callback();
+            }
+        }
+    }
+}

--- a/src/HCommons/HCommons.csproj
+++ b/src/HCommons/HCommons.csproj
@@ -5,7 +5,7 @@
         <Version>1.0.0</Version>
         <Title>HCommons</Title>
         <Description>Commonly used types, functions, and extensions.</Description>
-        <PackageTags>Commons Monads Buffers Math</PackageTags>
+        <PackageTags>Commons Monads Buffers Math Types Reflection</PackageTags>
 
         <!-- Override Directory.Build.props to allow Nuget generation -->
         <IsPackable>true</IsPackable>
@@ -19,6 +19,7 @@
         <ProjectReference Include="..\HCommons.Math\HCommons.Math.csproj" />
         <ProjectReference Include="..\HCommons.Void\HCommons.Void.csproj" />
         <ProjectReference Include="..\HCommons.Disposables\HCommons.Disposables.csproj" />
+        <ProjectReference Include="..\HCommons.Reflection\HCommons.Reflection.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- add the `HCommons.Reflection` NuGet project and include it in the umbrella package
- add `RuntimeTypeCache` with immutable cached queries, incremental assembly-load processing, explicit clearing, and disposable synchronized bindings
- handle partial reflection loads and annotate trimming-sensitive APIs
- add multi-target tests with a dynamically loaded fixture assembly
- add BenchmarkDotNet coverage and document Unity, trimming, dynamic assembly, and unloadability considerations

## Why

Runtime type discovery had become a recurring pattern, but rescanning every loaded assembly for every query is expensive and can become stale when assemblies load later. This package provides a dependency-free runtime cache suitable for ordinary .NET projects and Unity player code while keeping the API broad enough for future reflection and type utilities.

## Validation

- `dotnet build HCommons.sln -c Release --no-restore -m:1` — succeeded with 0 warnings and 0 errors
- `dotnet test src/HCommons.Tests/HCommons.Tests.csproj -c Release --no-build --no-restore` — 1,052 tests passed on each of .NET 6, .NET 8, .NET 9, and .NET Framework 4.8
- `dotnet pack src/HCommons.Reflection/HCommons.Reflection.csproj -c Release --no-build --no-restore` — produced the expected four-framework NuGet package
