### PR TITLE
ci: use NuGet trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,9 @@ jobs:
 
   publish:
     needs: [check-versions, test]
-    permissions: write-all # For creating tags and pushing packages
+    permissions:
+      contents: write # Create GitHub releases and tags
+      id-token: write # Request a GitHub OIDC token for NuGet trusted publishing
     if: needs.check-versions.outputs.has-updates == 'true'
     runs-on: ubuntu-24.04
     strategy:
@@ -239,11 +241,18 @@ jobs:
           path: ./artifacts/*.nupkg
           if-no-files-found: error
 
+      - name: NuGet login (OIDC to temporary API key)
+        if: ${{ inputs.dry-run == false }}
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to NuGet
         if: ${{ inputs.dry-run == false }}
         run: |
           dotnet nuget push "./artifacts/*.nupkg" \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
             --source "https://api.nuget.org/v3/index.json" \
             --skip-duplicate
 


### PR DESCRIPTION
## Summary

- grant the release job the minimal `contents: write` and `id-token: write` permissions
- exchange GitHub's OIDC token for a short-lived NuGet API key with `NuGet/login@v1`
- use the temporary key for package publishing while keeping dry runs authentication-free
- remove the workflow's dependency on the long-lived `NUGET_API_KEY` secret

## Why

Trusted publishing eliminates the need to store and rotate a long-lived NuGet API key and narrows the release job's GitHub permissions.

## Setup required

Before the first release, configure a nuget.org trusted publishing policy for `Hissal/HCommons` and workflow file `release.yml`, then add the nuget.org profile name as the GitHub Actions secret `NUGET_USER`.

## Validation

- parsed `.github/workflows/release.yml` successfully as YAML
- `git diff --check`
- confirmed no workflow references remain to `secrets.NUGET_API_KEY`

`actionlint` was not available locally.